### PR TITLE
Add option to let users only delete their own jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Detailed documentation is in the "docs" directory.
       ),
       'JOB_SYSTEM_ICON': (
         'job_system_app/img/default.ico', 'Icon of the Job System application'
+      ),
+      'ONLY_OWNER_CAN_STOP_JOB': (
+        True, 'Users can only stop their own jobs.', bool
       )
     }
 

--- a/job_system_frontend/settings.py
+++ b/job_system_frontend/settings.py
@@ -16,3 +16,10 @@ class Settings:
             return config.JOB_SYSTEM_ICON
         else:
             return 'job_system_frontend/img/default.ico'
+
+    @property
+    def ONLY_OWNER_CAN_STOP_JOB(self):
+        if 'ONLY_OWNER_CAN_STOP_JOB' in dir(config):
+            return config.ONLY_OWNER_CAN_STOP_JOB
+        else:
+            return False

--- a/job_system_frontend/templates/job_system_frontend/job_list.html
+++ b/job_system_frontend/templates/job_system_frontend/job_list.html
@@ -18,7 +18,7 @@
                     var job_action_col = job_row.find("td:nth-child(6)");
                     if (job['status'] == 'initialized') {
                         job_status_col.html(job["status"]);
-                        if ({{ is_system_user|lower }}) {
+                        if ({{ is_system_user|lower }} && (!{{ only_owner_can_stop_job|lower }} || job['owner'] == {{ user.username }})) {
                             job_action_col.find("a.btn-stop").removeClass('disabled');
                         }
                     } else if (job['status'] == 'in progress') {
@@ -29,7 +29,7 @@
                         //alert(JSON.stringify(progress, null, 4));
                         job_status_col.html(progress.get(0).outerHTML);
                         
-                        if ({{ is_system_user|lower }}) {
+                        if ({{ is_system_user|lower }} && (!{{ only_owner_can_stop_job|lower }} || job['owner'] == {{ user.username }})) {
                             job_action_col.find("a.btn-stop").removeClass('disabled');
                         }
                     } else {
@@ -119,6 +119,7 @@
                 url: "{% url 'job_system_api:job_list' %}" + job_id,
                 contentType: "application/json"
             }).done(function( job ) {
+
                 if (job['status'] == 'initialized') {
                     job['status'] = 'canceled';
                 }
@@ -221,7 +222,7 @@
                     </a>
                     -->
                     <a
-                        {% if not is_system_user or job.status != "initialized" and job.status != "in progress" %}
+                        {% if not is_system_user or job.status != "initialized" and job.status != "in progress" or job.owner != user.username and only_owner_can_stop_job %}
                             class="btn btn-danger btn-sm btn-stop disabled"
                         {% else %}
                             class="btn btn-danger btn-sm btn-stop"

--- a/job_system_frontend/templatetags/setting_extras.py
+++ b/job_system_frontend/templatetags/setting_extras.py
@@ -9,6 +9,12 @@ register = template.Library()
 def app_title():
     return settings.APP_TITLE
 
+
 @register.simple_tag
 def app_icon():
     return settings.APP_ICON
+
+
+@register.simple_tag
+def only_owner_can_stop_job():
+    return settings.ONLY_OWNER_CAN_STOP_JOB

--- a/job_system_frontend/views.py
+++ b/job_system_frontend/views.py
@@ -15,6 +15,7 @@ from datetime import timedelta
 
 from job_system_api.models import JobTemplate, Job, JobParameter, JobLogEntry
 from job_system_frontend.forms import JobForm, JobParameterFormSet
+from job_system_frontend import settings
 
 
 def index(request):
@@ -37,6 +38,7 @@ class JobListView(FilterView):
         context = super(JobListView, self).get_context_data(**kwargs)
         context['is_system_user'] = \
             self.request.user.groups.filter(name='jobsys').exists()
+        context['only_owner_can_stop_job'] = settings.ONLY_OWNER_CAN_STOP_JOB
         context['log_levels'] = \
             JobLogEntry._meta.get_field('level').flatchoices
         return context


### PR DESCRIPTION
This adds the option ```ONLY_OWNER_CAN_STOP_JOB``` to the constance config. 

If set to ```True```, users can *only* stop their own jobs. Otherwise, every user can stop *any* running job.

Details:
- Implemented as check when enabling/disabling the stop button.
- Default is set to ```False``` in ```job_system_frontend/settings.py``` in order to be consistent with the current behaviour.

 